### PR TITLE
USI LifeSupport dependent on USI Tools?

### DIFF
--- a/USI-LS.netkan
+++ b/USI-LS.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105"
 	},
 	"depends" : [
+		{ "name": "USITools" },
 		{
 			"name": "ModuleManager",
 			"min_version": "2.5.1"


### PR DESCRIPTION
Noticed a lot of exceptions after a clean CKAN reinstall and that USI Tools is in the USI-LS download, yet not installed via ckan.

best regards,
Y3mo