### PR TITLE
Update CommunityResourcePack.netkan

### DIFF
--- a/CommunityResourcePack.netkan
+++ b/CommunityResourcePack.netkan
@@ -20,5 +20,14 @@
 			"install_to": "GameData"
 		}
 	],
-	"x_last_revision_by": "harryyoung"
+	"x_last_revision_by": "dewiniaid",
+	"x_netkan_override": [
+		{
+			"version": "0.5.1.0",
+			"override": {
+				"ksp_version_min": "1.0.0",
+				"ksp_version_max": "1.1.99"
+			}
+		}
+        ]
 }


### PR DESCRIPTION
While it looks like an updated release of CRP is currently in the pipeline, the only change seems to be with versioning.

This overrides the currently available (0.5.1.0) release of CRP to state that it is compatible with KSP up to 1.1.99.  Since this is only configs, it's exceedingly unlikely a minor version bump in KSP would break anything.  The CRP release in the pipeline has a corrected .version file and thus won't need the override going forward.