### PR TITLE
Kerbalism no longer conflict with CPR.

### DIFF
--- a/CommunityResourcePack.netkan
+++ b/CommunityResourcePack.netkan
@@ -11,9 +11,6 @@
 	"resources" : {
 		"homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105"
 	},
-	"conflicts" : [
-		{ "name": "Kerbalism" }
-	],
 	"install" : [
 		{
 			"file": "GameData/CommunityResourcePack",


### PR DESCRIPTION
v0.9.9.5 of Kerbalism fixed the conflict with CommunityResourcePack, which in detail, "food/oxygen properties have been changed to match CRP ones".
https://github.com/ShotgunNinja/Kerbalism/releases/tag/v0.9.9.5