### PR TITLE
USI-Core fixes

### DIFF
--- a/USI-Core.netkan
+++ b/USI-Core.netkan
@@ -22,8 +22,9 @@
 	],
 	"install" : [
 		{
-			"file"	   : "GameData/UmbraSpaceIndustries",
-			"install_to" : "GameData"
+			"file"			: "GameData/UmbraSpaceIndustries",
+			"install_to"	: "GameData/UmbraSpaceIndustries",
+			"filter" 		: [ "FX", "Konstruction" ]
 		}
 	],
 	"x_last_revision_by": "harryyoung"


### PR DESCRIPTION
Should resolve KSP-CKAN/CKAN#1834.  Also ended up pointing directly at the USI-Core version file so that `netkan.exe` would accept the data (similar to what was done in #7)

I'm not entirely sure how to test whether this actually fixes the issue, given the way NetKAN works (and not really familiar enough with CKAN/NetKAN's inner workings to want to try, unfortunately).