### PR TITLE
SoundingRockets install specificity

### DIFF
--- a/SoundingRockets.netkan
+++ b/SoundingRockets.netkan
@@ -19,9 +19,9 @@
 	],
 	"install": [
 	{
-		"file": "GameData/UmbraSpaceIndustries",
-		"install_to": "GameData"
+		"file": "GameData/UmbraSpaceIndustries/SoundingRockets",
+		"install_to": "GameData/UmbraSpaceIndustries"
 	}
 	],
-	"x_last_revision_by": "harryyoung"
+	"x_last_revision_by": "politas"
 }


### PR DESCRIPTION
Konstruction is installed as part of the USI-Tools dependency, we can't install it twice.