### PR TITLE
Remove `provides` relationship

### DIFF
--- a/Konstruction.netkan
+++ b/Konstruction.netkan
@@ -11,7 +11,6 @@
 	"resources": {
 		"homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/"
 	},
-	"provides"	   : [ "Konstruction" ],
 	"depends" : [
 		{ "name" : "USITools" },
 		{ "name" : "CommunityResourcePack" },


### PR DESCRIPTION
Identifier `x` implicitly provides `x`. Due to the explicit relationship when a user tries to install MKS (which depends `Konstruction` they are presented with an odd selection:

http://puu.sh/rOinM/61500bccaa.png