### PR TITLE
Fix ExpPack

### DIFF
--- a/USI-EXP.netkan
+++ b/USI-EXP.netkan
@@ -42,9 +42,9 @@
 			"install_to" : "GameData/UmbraSpaceIndustries"
 		},
 		{
-			"find"	   : "UmbraSpaceIndustries/SubPack",
-			"install_to" : "GameData/UmbraSpaceIndustries"
+			"find"	   : "UmbraSpaceIndustries/SubPack/Otter",
+			"install_to" : "GameData/UmbraSpaceIndustries/SubPack"
 		}
 	],
-	"x_last_revision_by": "Blu3wolf"
+	"x_last_revision_by": "Olympic1"
 }


### PR DESCRIPTION
CKAN is not indexing v0.7.4.0 because it can't find files in `SubPack`, this fixes that problem.