### PR TITLE
Add MM depends

### DIFF
--- a/AlcubierreStandalone.netkan
+++ b/AlcubierreStandalone.netkan
@@ -14,6 +14,9 @@
 	"conflicts" : [
 		{ "name": "SETI-CommunityTechTree" }
 	],
+	"depends": [
+		{ "name": "ModuleManager" }
+	],
 	"install": [
 		{
 			"find": "UmbraSpaceIndustries/WarpDrive",

--- a/CommunityResourcePack.netkan
+++ b/CommunityResourcePack.netkan
@@ -11,6 +11,9 @@
 	"resources" : {
 		"homepage" : "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/"
 	},
+	"depends": [
+		{ "name": "ModuleManager" }
+	],
 	"install" : [
 		{
 			"file": "GameData/CommunityResourcePack",

--- a/SoundingRockets.netkan
+++ b/SoundingRockets.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{
 			"name": "USITools",
 			"min_version": "0.9.0.0"
@@ -21,10 +22,10 @@
 		{ "name": "SETI-CommunityTechTree" }
 	],
 	"install": [
-	{
-		"file": "GameData/UmbraSpaceIndustries/SoundingRockets",
-		"install_to": "GameData/UmbraSpaceIndustries"
-	}
+		{
+			"file": "GameData/UmbraSpaceIndustries/SoundingRockets",
+			"install_to": "GameData/UmbraSpaceIndustries"
+		}
 	],
 	"x_last_revision_by": "DoktorKrogg"
 }

--- a/USI-NuclearRockets.netkan
+++ b/USI-NuclearRockets.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{
 			"name": "USITools",
 			"min_version": "0.9.0.0"

--- a/USITools.netkan
+++ b/USITools.netkan
@@ -15,6 +15,9 @@
 	"conflicts" : [
 		{ "name": "SETI-CommunityTechTree" }
 	],
+	"depends": [
+		{ "name": "ModuleManager" }
+	],
 	"install" : [
 		{
 			"file"	   : "GameData/000_USITools",
@@ -23,7 +26,7 @@
 		{
 			"find"	   : "UmbraSpaceIndustries/FX",
 			"install_to" : "GameData/UmbraSpaceIndustries"
-		}		
+		}
 	],
 	"x_last_revision_by": "DoktorKrogg"
 }


### PR DESCRIPTION
Several mods here use ModuleManager syntax but don't depend on it in their metanetkans.

Now they do.

Tagginng @BobPalmer since not everyone has notifications turned on for GitHub pull requests.