### PR TITLE
Fix syntax error for UKS

### DIFF
--- a/UKS.netkan
+++ b/UKS.netkan
@@ -66,7 +66,7 @@
 		{
 			"find"	   : "UmbraSpaceIndustries/Karibou",
 			"install_to" : "GameData/UmbraSpaceIndustries"
-		}
+		},
 		{
 			"find"	   : "UmbraSpaceIndustries/WOLF",
 			"install_to" : "GameData/UmbraSpaceIndustries"


### PR DESCRIPTION
In JSON, objects in an array must be separated by commas. Currently one is missing, which is blocking this from being updated on CKAN. Now it's fixed.

Tagging @BobPalmer to make sure GitHub sends a notification.

We just finished a tool to catch things like this automatically, probably worth setting up in this repo:

- https://github.com/KSP-CKAN/xKAN-meta_testing